### PR TITLE
fix for issues/7

### DIFF
--- a/configure/configure.go
+++ b/configure/configure.go
@@ -25,10 +25,9 @@ type config struct {
 
 func Cfgcli(cmd *cli.Cmd) {
 	cmd.Action = func() {
-		usr, err := user.Current()
-		validate(err)
+		usrHome := os.Getenv("HOME")
 
-		file := usr.HomeDir + "/.kumoru/config"
+		file := usrHome + "/.kumoru/config"
 		if _, err := os.Stat(file); err == nil {
 			fmt.Println(file, "configuration file already exists.")
 			os.Exit(1)


### PR DESCRIPTION
Fixes #7 os.Current not available during cross compile issue.

```go
$ builds/osx/kumoru configure
2015/11/03 13:43:57 user: Current not implemented on darwin/amd64
```
